### PR TITLE
Establish task crud tests via http

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -58,3 +58,16 @@ func checkResponseCode(t *testing.T, expected, actual int) {
     t.Errorf("Expected response code %d. Got %d\n", expected, actual)
   }
 }
+
+func TestEmptyTable(t *testing.T) {
+  clearTable()
+
+  req, _ := http.NewRequest("GET", "/tasks", nil)
+  response := executeRequest(req)
+
+  checkResponseCode(t, http.StatusOK, response.Code)
+
+  if body := response.Body.String(); body != "[]" {
+    t.Errorf("Expected an empty array. Got %s", body)
+  }
+}

--- a/main_test.go
+++ b/main_test.go
@@ -87,3 +87,29 @@ func TestGetNonExistentTask(t *testing.T) {
     t.Errorf("Expected the 'error' key of the response to be set to 'Task not found'. Got '%'", m["error"])
   }
 }
+
+func TestCreateTask(t *testing.T) {
+  clearTable()
+
+  payload := []byte(`{"description":"test task","completed":false}`)
+
+  req, _ := http.NewRequest("POST", "/task", bytes.NewBuffer(payload))
+  response := executeRequest(req)
+
+  checkResponseCode(t, http.StatusCreated, response.Code)
+
+  var m map[string]interface{}
+  json.Unmarshal(response.Body.Bytes(), &m)
+
+  if m["description"] != "test task" {
+    t.Errorf("Expected task description to be 'test task'. Got '%v'", m["description"])
+  }
+
+  if m["completed"] != false {
+    t.Errorf("Expected task completed to be 'false'. Got '%v'", m["completed"])
+  }
+
+  if m["id"] != 1.0 {
+    t.Errorf("Expected task ID to be '1'. Got '%v'", m["id"])
+  }
+}

--- a/main_test.go
+++ b/main_test.go
@@ -113,3 +113,23 @@ func TestCreateTask(t *testing.T) {
     t.Errorf("Expected task ID to be '1'. Got '%v'", m["id"])
   }
 }
+
+func TestDeleteTask(t *testing.T) {
+  clearTable()
+  addTasks(1)
+
+  req, _ := http.NewRequest("GET", "/tasks")
+  response_1 := executeRequest(req)
+
+  req, _ = http.NewRequest("DELETE", "task/1", nil)
+  response := executeRequest(req)
+
+  checkResponseCode(t, http.StatusOK, response.Code)
+
+  req, _ = http.NewRequest("GET", "/tasks")
+  response_2 := executeRequest(req)
+
+  if response_1 != response_2 {
+    t.Errorf("Expected one task to be deleted and not found in the second request")
+  }  
+}

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@ import (
   "net/http"
   "net/http/httptest"
   "encoding/json"
+  "strconv"
 )
 
 // Sets application we want to test as 'a'
@@ -88,6 +89,27 @@ func TestGetNonExistentTask(t *testing.T) {
   }
 }
 
+func TestGetTask(t *testing.T) {
+  clearTable()
+  addTasks(1)
+
+  req, _ := http.NewRequest("GET", "task/1", nil)
+  response := executeRequest(req)
+
+  checkResponseCode(t, http.StatusOK, response.Code)
+}
+
+func addTasks(count int) {
+  if count < 1 {
+    count = 1
+  }
+
+  for i := 0; i < count; i++ {
+    statement := fmt.Sprintf("INSERT INTO tasks(description, completed) VALUES('%s', false)", ("Task " + strconv.Itoa(i+1)))
+    a.DB.Exec(statement)
+  }
+}
+
 func TestCreateTask(t *testing.T) {
   clearTable()
 
@@ -118,18 +140,15 @@ func TestDeleteTask(t *testing.T) {
   clearTable()
   addTasks(1)
 
-  req, _ := http.NewRequest("GET", "/tasks")
-  response_1 := executeRequest(req)
-
-  req, _ = http.NewRequest("DELETE", "task/1", nil)
+  req, _ := http.NewRequest("GET", "/task/1", nil)
   response := executeRequest(req)
-
   checkResponseCode(t, http.StatusOK, response.Code)
 
-  req, _ = http.NewRequest("GET", "/tasks")
-  response_2 := executeRequest(req)
+  req, _ = http.NewRequest("DELETE", "/task/1", nil)
+  response = executeRequest(req)
+  checkResponseCode(t, http.StatusOK, response.Code)
 
-  if response_1 != response_2 {
-    t.Errorf("Expected one task to be deleted and not found in the second request")
-  }  
+  req, _ = http.NewRequest("GET", "/task/1", nil)
+  response = executeRequest(req)
+  checkResponseCode(t, http.StatusNotFound, response.Code)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
   "os"
+  "fmt"
+  "bytes"
   "log"
   "testing"
   "net/http"
@@ -85,7 +87,7 @@ func TestGetNonExistentTask(t *testing.T) {
   var m map[string]string
   json.Unmarshal(response.Body.Bytes(), &m)
   if m["error"] != "Task not found" {
-    t.Errorf("Expected the 'error' key of the response to be set to 'Task not found'. Got '%'", m["error"])
+    t.Errorf("Expected the 'error' key of the response to be set to 'Task not found'. Got '%s'", m["error"])
   }
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,8 @@ import (
   "os"
   "log"
   "testing"
+  "net/http"
+  "net/http/httptest"
 )
 
 // Sets application we want to test as 'a'
@@ -43,3 +45,16 @@ CREATE TABLE IF NOT EXISTS tasks
   completed BOOLEAN NOT NULL,
   description VARCHAR(255) NOT NULL
 )`
+
+func executeRequest(req *http.Request) *httptest.ResponseRecorder {
+  rr := httptest.NewRecorder()
+  a.Router.ServeHTTP(rr, req)
+
+  return rr
+}
+
+func checkResponseCode(t *testing.T, expected, actual int) {
+  if expected != actual {
+    t.Errorf("Expected response code %d. Got %d\n", expected, actual)
+  }
+}

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
   "testing"
   "net/http"
   "net/http/httptest"
+  "encoding/json"
 )
 
 // Sets application we want to test as 'a'
@@ -69,5 +70,20 @@ func TestEmptyTable(t *testing.T) {
 
   if body := response.Body.String(); body != "[]" {
     t.Errorf("Expected an empty array. Got %s", body)
+  }
+}
+
+func TestGetNonExistentTask(t *testing.T) {
+  clearTable()
+
+  req, _ := http.NewRequest("GET", "/task/45", nil)
+  response := executeRequest(req)
+
+  checkResponseCode(t, http.StatusNotFound, response.Code)
+
+  var m map[string]string
+  json.Unmarshal(response.Body.Bytes(), &m)
+  if m["error"] != "Task not found" {
+    t.Errorf("Expected the 'error' key of the response to be set to 'Task not found'. Got '%'", m["error"])
   }
 }


### PR DESCRIPTION
## What functionality does this accomplish?
Closes #3 

**Description:**
Adds tests for creating, getting, and deleting tasks via http requests/responses. Tests integrate http calls with Mysql. 

## What did you struggle on to complete?
No struggles. 

## Current Test Suite:
Test failures are intentional. No methods have been written yet.
```
jamescape~/go/task_list[establish_task_crud_tests_via_http] go test -v
=== RUN   TestEmptyTable
    TestEmptyTable: main_test.go:62: Expected response code 200. Got 404
    TestEmptyTable: main_test.go:75: Expected an empty array. Got 404 page not found
--- FAIL: TestEmptyTable (0.01s)
=== RUN   TestGetNonExistentTask
    TestGetNonExistentTask: main_test.go:90: Expected the 'error' key of the response to be set to 'Task not found'. Got ''
--- FAIL: TestGetNonExistentTask (0.00s)
=== RUN   TestGetTask
    TestGetTask: main_test.go:62: Expected response code 200. Got 301
--- FAIL: TestGetTask (0.00s)
=== RUN   TestCreateTask
    TestCreateTask: main_test.go:62: Expected response code 201. Got 404
    TestCreateTask: main_test.go:129: Expected task description to be 'test task'. Got '<nil>'
    TestCreateTask: main_test.go:133: Expected task completed to be 'false'. Got '<nil>'
    TestCreateTask: main_test.go:137: Expected task ID to be '1'. Got '<nil>'
--- FAIL: TestCreateTask (0.00s)
=== RUN   TestDeleteTask
    TestDeleteTask: main_test.go:62: Expected response code 200. Got 404
    TestDeleteTask: main_test.go:62: Expected response code 200. Got 404
--- FAIL: TestDeleteTask (0.00s)
FAIL
exit status 1
FAIL	_/Users/jamescape/go/task_list	0.043s
```

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas

## Helpful Resources:
[Following this guide](https://medium.com/@kelvin_sp/building-and-testing-a-rest-api-in-golang-using-gorilla-mux-and-mysql-1f0518818ff6)