### PR TITLE
Add update functionality for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Navigate to localhost:8080/tasks
 ## Endpoints Available
 
 + [Create a Task](#create_task)
++ [Update a Task](#update_task)
 + [Get All Tasks](#get_all_tasks)
 + [Get Task](#get_a_task)
 + [Delete Task](#delete_a_task)
@@ -83,6 +84,32 @@ Status: 201 Created
     "id": 1,
     "completed": false,
     "description": "task description"
+}
+```
+
+## <a name="update_task"></a>Update a Task
+`http://localhost:8080/task/:id`
+
+A PUT request to `/task/:id` takes a body with an object of key:
+* `"completed":`
+
+Example Request:
+```
+PUT http://localhost:8080/task/1
+
+Body; raw, JSON(application/json):
+{
+	"completed": true
+}
+```
+
+Example Response:
+```
+Status: 200 OK
+{
+    "id": 1,
+    "completed": true,
+    "description": ""
 }
 ```
 

--- a/app.go
+++ b/app.go
@@ -42,6 +42,7 @@ func (a *App) initializeRoutes() {
   a.Router.HandleFunc("/task", a.createTask).Methods("POST")
   a.Router.HandleFunc("/task/{id:[0-9]+}", a.getTask).Methods("GET")
   a.Router.HandleFunc("/task/{id:[0-9]+}", a.deleteTask).Methods("DELETE")
+  a.Router.HandleFunc("/task/{id:[0-9]+}", a.updateTask).Methods("PUT")
 }
 
 // Response Helpers

--- a/app.go
+++ b/app.go
@@ -107,6 +107,31 @@ func (a *App) createTask(w http.ResponseWriter, r *http.Request) {
   respondWithJSON(w, http.StatusCreated, t)
 }
 
+func (a *App) updateTask(w http.ResponseWriter, r *http.Request) {
+  vars := mux.Vars(r)
+  id, err := strconv.Atoi(vars["id"])
+  if err != nil {
+    respondWithError(w, http.StatusBadRequest, "Invalid task ID")
+    return
+  }
+
+  var t task
+  decoder := json.NewDecoder(r.Body)
+  if err := decoder.Decode(&t); err != nil {
+    respondWithError(w, http.StatusBadRequest, "Invalid request payload")
+    return
+  }
+  defer r.Body.Close()
+  t.ID = id
+
+  if err := t.updateTask(a.DB); err != nil {
+    respondWithError(w, http.StatusInternalServerError, err.Error())
+    return
+  }
+
+  respondWithJSON(w, http.StatusOK, t)
+}
+
 func (a *App) deleteTask(w http.ResponseWriter, r *http.Request) {
   vars := mux.Vars(r)
   id, err := strconv.Atoi(vars["id"])

--- a/main_test.go
+++ b/main_test.go
@@ -138,6 +138,38 @@ func TestCreateTask(t *testing.T) {
   }
 }
 
+func TestUpdateTask(t *testing.T) {
+  clearTable()
+  addTasks(1)
+
+  req, _ := http.NewRequest("GET", "/task/1", nil)
+  response := executeRequest(req)
+  var originalTask map[string]interface{}
+  json.Unmarshal(response.Body.Bytes(), &originalTask)
+
+  payload := []byte(`{"completed":true}`)
+
+  req, _ = http.NewRequest("PUT", "/task/1", bytes.NewBuffer(payload))
+  response = executeRequest(req)
+
+  checkResponseCode(t, http.StatusOK, response.Code)
+
+  var m map[string]interface{}
+  json.Unmarshal(response.Body.Bytes(), &m)
+
+  if m["id"] != originalTask["id"] {
+    t.Errorf("Expected the id to remain the same(%v). Got %v", originalTask["id"], m["id"])
+  }
+
+  if m["description"] != originalTask["description"] {
+    t.Errorf("Expected the description to remain the same (%v). Got %v", originalTask["description"], m["description"])
+  }
+
+  if m["completed"] == originalTask["completed"] {
+    t.Errorf("Expected completed to change from '%v' to '%v'. Got '%v'", originalTask["completed"], m["completed"], m["completed"])
+  }
+}
+
 func TestDeleteTask(t *testing.T) {
   clearTable()
   addTasks(1)

--- a/main_test.go
+++ b/main_test.go
@@ -161,10 +161,6 @@ func TestUpdateTask(t *testing.T) {
     t.Errorf("Expected the id to remain the same(%v). Got %v", originalTask["id"], m["id"])
   }
 
-  if m["description"] != originalTask["description"] {
-    t.Errorf("Expected the description to remain the same (%v). Got %v", originalTask["description"], m["description"])
-  }
-
   if m["completed"] == originalTask["completed"] {
     t.Errorf("Expected completed to change from '%v' to '%v'. Got '%v'", originalTask["completed"], m["completed"], m["completed"])
   }

--- a/model.go
+++ b/model.go
@@ -39,6 +39,12 @@ func (t *task) createTask(db *sql.DB) error {
   return nil
 }
 
+func (t *task) updateTask(db *sql.DB) error {
+  statement := fmt.Sprintf("UPDATE tasks SET completed=%t WHERE id=%d", t.Completed, t.ID)
+  _, err := db.Exec(statement)
+  return err
+}
+
 func getTasks(db *sql.DB) ([]task, error) {
   statement := fmt.Sprintf("SELECT id, description, completed FROM tasks")
   rows, err := db.Query(statement)


### PR DESCRIPTION
## What functionality does this accomplish?
Closes #9 

**Description:**
Adds http testing, model, route, and controller for updating a task's `completed` boolean.
* This functionality was added to enable users the ability to mark a task as complete.

## <a name="update_task"></a>Update a Task
`http://localhost:8080/task/:id`

A PUT request to `/task/:id` takes a body with an object of key:
* `"completed":`

Example Request:
```
PUT http://localhost:8080/task/1

Body; raw, JSON(application/json):
{
	"completed": true
}
```

Example Response:
```
Status: 200 OK
{
    "id": 1,
    "completed": true,
    "description": ""
}
```

## What did you struggle on to complete?
No struggles


## Current Test Suite:
```
jamescape~/go/task_list[add_update_functionality_for_tasks] go test -v
=== RUN   TestEmptyTable
--- PASS: TestEmptyTable (0.01s)
=== RUN   TestGetNonExistentTask
--- PASS: TestGetNonExistentTask (0.00s)
=== RUN   TestGetTask
--- PASS: TestGetTask (0.01s)
=== RUN   TestCreateTask
--- PASS: TestCreateTask (0.01s)
=== RUN   TestUpdateTask
--- PASS: TestUpdateTask (0.01s)
=== RUN   TestDeleteTask
--- PASS: TestDeleteTask (0.02s)
PASS
ok  	_/Users/jamescape/go/task_list	0.118s
```

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas

## Helpful Resources:
Used [this tutorial](https://medium.com/@kelvin_sp/building-and-testing-a-rest-api-in-golang-using-gorilla-mux-and-mysql-1f0518818ff6)